### PR TITLE
Remove utf-8 comment chars

### DIFF
--- a/lib/crc16.cc
+++ b/lib/crc16.cc
@@ -71,8 +71,6 @@ void checkSum(uint8_t *pDataIn, size_t len, uint8_t *sumHigh, uint8_t *sumLow)
 {
     uint8_t tableIndex = 0;
 
-    //采用len控制for循环结束，更灵活
-    //这样可以对input的一部分做计算
     size_t i = 0;
     if ((0 != len) && (NULL != pDataIn))
     {


### PR DESCRIPTION
Windows 10 VS2019由于unicode编码问题，无法通过编译，虽然win10系统设置里有utf8选项，我又不想修改系统环境，因为这样会造成其他软件意想不到的坑